### PR TITLE
use all lower-case letters for imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: go
+go_import_path: github.com/k8snetworkplumbingwg/network-attachment-definition-client
 install: true
 script: hack/verify-codegen.sh

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Based on https://github.com/openshift-evangelists/crd-code-generation
 
+**Note:** You have to clone/import this repository with all lower-case letters:
+
+```
+github.com/k8snetworkplumbingwg/network-attachment-definition-client
+```
+
 ## Getting Started
 
 First register the custom resource definition:

--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
 
-	clientset "github.com/K8sNetworkPlumbingWG/network-attachment-definition-client/pkg/client/clientset/versioned"
+	clientset "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned"
 )
 
 var (

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -5,9 +5,8 @@ set -o nounset
 set -o pipefail
 
 SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/..
-CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${SCRIPT_ROOT}; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ${GOPATH}/src/k8s.io/code-generator)}
 
 vendor/k8s.io/code-generator/generate-groups.sh all \
-  github.com/K8sNetworkPlumbingWG/network-attachment-definition-client/pkg/client github.com/K8sNetworkPlumbingWG/network-attachment-definition-client/pkg/apis \
+  github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis \
   k8s.cni.cncf.io:v1 \
   --go-header-file ${SCRIPT_ROOT}/hack/custom-boilerplate.go.txt

--- a/pkg/apis/k8s.cni.cncf.io/v1/register.go
+++ b/pkg/apis/k8s.cni.cncf.io/v1/register.go
@@ -5,7 +5,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	k8scnicncfio "github.com/K8sNetworkPlumbingWG/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io"
+	k8scnicncfio "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io"
 )
 
 // SchemeGroupVersion is group version used to register these objects

--- a/pkg/client/clientset/versioned/clientset.go
+++ b/pkg/client/clientset/versioned/clientset.go
@@ -19,7 +19,7 @@ limitations under the License.
 package versioned
 
 import (
-	k8scnicncfiov1 "github.com/K8sNetworkPlumbingWG/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
+	k8scnicncfiov1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"

--- a/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -19,9 +19,9 @@ limitations under the License.
 package fake
 
 import (
-	clientset "github.com/K8sNetworkPlumbingWG/network-attachment-definition-client/pkg/client/clientset/versioned"
-	k8scnicncfiov1 "github.com/K8sNetworkPlumbingWG/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
-	fakek8scnicncfiov1 "github.com/K8sNetworkPlumbingWG/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1/fake"
+	clientset "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned"
+	k8scnicncfiov1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
+	fakek8scnicncfiov1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1/fake"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	k8scnicncfiov1 "github.com/K8sNetworkPlumbingWG/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	k8scnicncfiov1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -19,7 +19,7 @@ limitations under the License.
 package scheme
 
 import (
-	k8scnicncfiov1 "github.com/K8sNetworkPlumbingWG/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	k8scnicncfiov1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1/fake/fake_k8s.cni.cncf.io_client.go
+++ b/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1/fake/fake_k8s.cni.cncf.io_client.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	v1 "github.com/K8sNetworkPlumbingWG/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
+	v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
 )

--- a/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1/fake/fake_networkattachmentdefinition.go
+++ b/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1/fake/fake_networkattachmentdefinition.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	k8scnicncfiov1 "github.com/K8sNetworkPlumbingWG/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	k8scnicncfiov1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1/k8s.cni.cncf.io_client.go
+++ b/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1/k8s.cni.cncf.io_client.go
@@ -19,8 +19,8 @@ limitations under the License.
 package v1
 
 import (
-	v1 "github.com/K8sNetworkPlumbingWG/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
-	"github.com/K8sNetworkPlumbingWG/network-attachment-definition-client/pkg/client/clientset/versioned/scheme"
+	v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	"github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/scheme"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	rest "k8s.io/client-go/rest"
 )

--- a/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1/networkattachmentdefinition.go
+++ b/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1/networkattachmentdefinition.go
@@ -19,8 +19,8 @@ limitations under the License.
 package v1
 
 import (
-	v1 "github.com/K8sNetworkPlumbingWG/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
-	scheme "github.com/K8sNetworkPlumbingWG/network-attachment-definition-client/pkg/client/clientset/versioned/scheme"
+	v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	scheme "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/scheme"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/informers/externalversions/factory.go
+++ b/pkg/client/informers/externalversions/factory.go
@@ -23,9 +23,9 @@ import (
 	sync "sync"
 	time "time"
 
-	versioned "github.com/K8sNetworkPlumbingWG/network-attachment-definition-client/pkg/client/clientset/versioned"
-	internalinterfaces "github.com/K8sNetworkPlumbingWG/network-attachment-definition-client/pkg/client/informers/externalversions/internalinterfaces"
-	k8scnicncfio "github.com/K8sNetworkPlumbingWG/network-attachment-definition-client/pkg/client/informers/externalversions/k8s.cni.cncf.io"
+	versioned "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned"
+	internalinterfaces "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/informers/externalversions/internalinterfaces"
+	k8scnicncfio "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/informers/externalversions/k8s.cni.cncf.io"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/informers/externalversions/generic.go
+++ b/pkg/client/informers/externalversions/generic.go
@@ -21,7 +21,7 @@ package externalversions
 import (
 	"fmt"
 
-	v1 "github.com/K8sNetworkPlumbingWG/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
 )

--- a/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -21,7 +21,7 @@ package internalinterfaces
 import (
 	time "time"
 
-	versioned "github.com/K8sNetworkPlumbingWG/network-attachment-definition-client/pkg/client/clientset/versioned"
+	versioned "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	cache "k8s.io/client-go/tools/cache"

--- a/pkg/client/informers/externalversions/k8s.cni.cncf.io/interface.go
+++ b/pkg/client/informers/externalversions/k8s.cni.cncf.io/interface.go
@@ -19,8 +19,8 @@ limitations under the License.
 package k8s
 
 import (
-	internalinterfaces "github.com/K8sNetworkPlumbingWG/network-attachment-definition-client/pkg/client/informers/externalversions/internalinterfaces"
-	v1 "github.com/K8sNetworkPlumbingWG/network-attachment-definition-client/pkg/client/informers/externalversions/k8s.cni.cncf.io/v1"
+	internalinterfaces "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/informers/externalversions/internalinterfaces"
+	v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/informers/externalversions/k8s.cni.cncf.io/v1"
 )
 
 // Interface provides access to each of this group's versions.

--- a/pkg/client/informers/externalversions/k8s.cni.cncf.io/v1/interface.go
+++ b/pkg/client/informers/externalversions/k8s.cni.cncf.io/v1/interface.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	internalinterfaces "github.com/K8sNetworkPlumbingWG/network-attachment-definition-client/pkg/client/informers/externalversions/internalinterfaces"
+	internalinterfaces "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/informers/externalversions/internalinterfaces"
 )
 
 // Interface provides access to all the informers in this group version.

--- a/pkg/client/informers/externalversions/k8s.cni.cncf.io/v1/networkattachmentdefinition.go
+++ b/pkg/client/informers/externalversions/k8s.cni.cncf.io/v1/networkattachmentdefinition.go
@@ -21,10 +21,10 @@ package v1
 import (
 	time "time"
 
-	k8scnicncfiov1 "github.com/K8sNetworkPlumbingWG/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
-	versioned "github.com/K8sNetworkPlumbingWG/network-attachment-definition-client/pkg/client/clientset/versioned"
-	internalinterfaces "github.com/K8sNetworkPlumbingWG/network-attachment-definition-client/pkg/client/informers/externalversions/internalinterfaces"
-	v1 "github.com/K8sNetworkPlumbingWG/network-attachment-definition-client/pkg/client/listers/k8s.cni.cncf.io/v1"
+	k8scnicncfiov1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	versioned "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned"
+	internalinterfaces "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/informers/externalversions/internalinterfaces"
+	v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/listers/k8s.cni.cncf.io/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/listers/k8s.cni.cncf.io/v1/networkattachmentdefinition.go
+++ b/pkg/client/listers/k8s.cni.cncf.io/v1/networkattachmentdefinition.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	v1 "github.com/K8sNetworkPlumbingWG/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"


### PR DESCRIPTION
Using upper-case letters in organization name breaks
kubevirt/code-generator <= 1.13. In order to prevent that, this client
must be always used with lower-letters: k8snetworkplumbingwg.