### PR TITLE
Add pci deviceId into network status

### DIFF
--- a/pkg/apis/k8s.cni.cncf.io/v1/types.go
+++ b/pkg/apis/k8s.cni.cncf.io/v1/types.go
@@ -41,12 +41,13 @@ type DNS struct {
 // NetworkStatus is for network status annotation for pod
 // +k8s:deepcopy-gen=false
 type NetworkStatus struct {
-	Name      string   `json:"name"`
-	Interface string   `json:"interface,omitempty"`
-	IPs       []string `json:"ips,omitempty"`
-	Mac       string   `json:"mac,omitempty"`
-	Default   bool     `json:"default,omitempty"`
-	DNS       DNS      `json:"dns,omitempty"`
+	Name      string                 `json:"name"`
+	Interface string                 `json:"interface,omitempty"`
+	IPs       []string               `json:"ips,omitempty"`
+	Mac       string                 `json:"mac,omitempty"`
+	Default   bool                   `json:"default,omitempty"`
+	DNS       DNS                    `json:"dns,omitempty"`
+	DeviceID  map[string]interface{} `json:"device-identification"`
 }
 
 // PortMapEntry for CNI PortMapEntry

--- a/pkg/utils/net-attach-def.go
+++ b/pkg/utils/net-attach-def.go
@@ -120,8 +120,8 @@ func GetNetworkStatus(pod *corev1.Pod) ([]v1.NetworkStatus, error) {
 	return netStatuses, err
 }
 
-// CreateNetworkStatus create NetworkStatus from CNI result
-func CreateNetworkStatus(r cnitypes.Result, networkName string, defaultNetwork bool) (*v1.NetworkStatus, error) {
+// CreateNetworkStatusWithDeviceID create NetworkStatus from CNI result and deviceID
+func CreateNetworkStatusWithDeviceID(r cnitypes.Result, networkName string, deviceID map[string]interface{}, defaultNetwork bool) (*v1.NetworkStatus, error) {
 	netStatus := &v1.NetworkStatus{}
 	netStatus.Name = networkName
 	netStatus.Default = defaultNetwork
@@ -153,7 +153,20 @@ func CreateNetworkStatus(r cnitypes.Result, networkName string, defaultNetwork b
 	v1dns := convertDNS(result.DNS)
 	netStatus.DNS = *v1dns
 
+	if deviceID != nil && len(deviceID) != 0 {
+		newMap := make(map[string]interface{})
+		for key, value := range deviceID {
+			newMap[key] = value
+		}
+		netStatus.DeviceID = newMap
+	}
+
 	return netStatus, nil
+}
+
+// CreateNetworkStatus create NetworkStatus from CNI result
+func CreateNetworkStatus(r cnitypes.Result, networkName string, defaultNetwork bool) (*v1.NetworkStatus, error) {
+	return CreateNetworkStatusWithDeviceID(r, networkName, nil, defaultNetwork)
 }
 
 // ParsePodNetworkAnnotation parses Pod annotation for net-attach-def and get NetworkSelectionElement


### PR DESCRIPTION
This commit adds DeviceID into NetworkStatus struct and provides
a new API to create NetworkStatus with deviceId if network contains
a pci device with it. This would help container application to find
out pci device for a network when network status is set through pod
annotations via k8s downward API.

Issue: https://github.com/intel/network-resources-injector/issues/20

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>