### PR TITLE
Add infiniband-guid attribute to Network Selection Element

### DIFF
--- a/pkg/apis/k8s.cni.cncf.io/v1/types.go
+++ b/pkg/apis/k8s.cni.cncf.io/v1/types.go
@@ -84,6 +84,9 @@ type NetworkSelectionElement struct {
 	// MacRequest contains an optional requested MAC address for this
 	// network attachment
 	MacRequest string `json:"mac,omitempty"`
+	// InfinibandGUIDRequest contains an optional requested Infiniband GUID
+	// address for this network attachment
+	InfinibandGUIDRequest string `json:"infiniband-guid,omitempty"`
 	// InterfaceRequest contains an optional requested name for the
 	// network interface this attachment will create in the container
 	InterfaceRequest string `json:"interface,omitempty"`


### PR DESCRIPTION
This commit defines `infiniband-guid` as a new network attachment
attribute as discussed in issue[1].

This attribute is defined be converted to `infinibandGUID` CNI runtime
config by delegate plugin.

[1] https://github.com/k8snetworkplumbingwg/multi-net-spec/issues/4