### PR TITLE
Move device-info version string to v1.0.0

### DIFF
--- a/pkg/apis/k8s.cni.cncf.io/v1/types.go
+++ b/pkg/apis/k8s.cni.cncf.io/v1/types.go
@@ -43,7 +43,7 @@ const (
 	DeviceInfoTypeVHostUser = "vhost-user"
 	DeviceInfoTypeMemif     = "memif"
 	DeviceInfoTypeVDPA      = "vdpa"
-	DeviceInfoVersion       = "v0.1.0"
+	DeviceInfoVersion       = "v1.0.0"
 )
 
 // DeviceInfo contains the information of the device associated


### PR DESCRIPTION
Last PR had version set to v0.1.0 incase updates needed to be made. Since 3-4 repos
need to pull this in, go ahead and move the device-info version string now.

Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>