### PR TITLE
Move device-info version string to 1.0.0

### DIFF
--- a/pkg/apis/k8s.cni.cncf.io/v1/types.go
+++ b/pkg/apis/k8s.cni.cncf.io/v1/types.go
@@ -43,7 +43,7 @@ const (
 	DeviceInfoTypeVHostUser = "vhost-user"
 	DeviceInfoTypeMemif     = "memif"
 	DeviceInfoTypeVDPA      = "vdpa"
-	DeviceInfoVersion       = "v1.0.0"
+	DeviceInfoVersion       = "1.0.0"
 )
 
 // DeviceInfo contains the information of the device associated


### PR DESCRIPTION
device-info-spec specifies the version string should be formatted as "1.0.0", not "v1.0.0",
so correcting const string in code.

Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>