### PR TITLE
Upgrade containernetworking/cni package dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/k8snetworkplumbingwg/network-attachment-definition-client
 go 1.12
 
 require (
-	github.com/containernetworking/cni v0.7.1
+	github.com/containernetworking/cni v0.8.1
 	github.com/emicklei/go-restful v2.10.0+incompatible // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdko
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/containernetworking/cni v0.7.1 h1:fE3r16wpSEyaqY4Z4oFrLMmIGfBYIKpPrHK31EJ9FzE=
-github.com/containernetworking/cni v0.7.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
+github.com/containernetworking/cni v0.8.1 h1:7zpDnQ3T3s4ucOuJ/ZCLrYBxzkg0AELFfII3Epo9TmI=
+github.com/containernetworking/cni v0.8.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
As I was working with SRIOV DP, it turned out that there is a vulnerability reported by SNYK scan tool in github.com/containernetworking/cni which is introduced into SRIOV DP indirectly through network-attachment-definition-client. I believe that version of this package could be updated.

Scan details below:

**HIGH SEVERITY**
**Directory Traversal** 

Vulnerable module:	github.com/containernetworking/cni/pkg/invoke
Introduced through:	github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/utils@#9d213757d22d
Exploit maturity:	No known exploit
Fixed in:	0.8.1

**Detailed paths**
Introduced through: github.com/k8snetworkplumbingwg/sriov-network-device-plugin@0.0.0 › github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/utils@#9d213757d22d › github.com/containernetworking/cni/libcni@0.8.0 › github.com/containernetworking/cni/pkg/invoke@0.8.0

**Overview**
Affected versions of this package are vulnerable to Directory Traversal. When specifying the plugin to load in the type field in the network configuration, it is possible to use special elements such as "../" separators to reference binaries elsewhere on the system. An attacker can use this to execute other existing binaries other than the cni plugins/types such as reboot.