### PR TITLE
Adding Status field to NetworkAttachmentDefinition

### DIFF
--- a/artifacts/networks-crd.yaml
+++ b/artifacts/networks-crd.yaml
@@ -13,15 +13,40 @@ spec:
     shortNames:
     - net-attach-def
   versions:
-    - name: v1
-      served: true
-      storage: true
-      schema:
-        openAPIV3Schema:
-          type: object
-          properties:
-            spec:
-              type: object
-              properties:
-                config:
-                  type: string
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              config:
+                type: string
+            required:
+            - config
+            type: object
+          status:
+            properties:
+              state:
+                type: string
+              observation:
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/apis/k8s.cni.cncf.io/v1/types.go
+++ b/pkg/apis/k8s.cni.cncf.io/v1/types.go
@@ -1,12 +1,12 @@
 package v1
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"net"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // +genclient
-// +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +resourceName=network-attachment-definitions
 
@@ -14,11 +14,45 @@ type NetworkAttachmentDefinition struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec NetworkAttachmentDefinitionSpec `json:"spec"`
+	Spec   NetworkAttachmentDefinitionSpec   `json:"spec"`
+	Status NetworkAttachmentDefinitionStatus `json:"status,omitempty"`
 }
+
+// StateType contains a valid NetworkAttachmentDefinition state
+type StateType string
+
+const (
+	// PendingState indicates NetworkAttachmentDefinition waiting to reconcile
+	PendingState StateType = "Pending"
+	// PendingObservationMessage is the default message for a
+	// NetworkAttachmentDefinition pending to be reconciled
+	PendingObservationMessage = "NetworkAttachmentDefinition waiting to be reconciled"
+	// SuccessState indicates NetworkAttachmentDefinition successfully reconcile
+	SuccessState StateType = "Success"
+	// FailureState indicates NetworkAttachmentDefinition has failed to reconcile
+	// for one or more reasons
+	FailureState StateType = "Failure"
+)
 
 type NetworkAttachmentDefinitionSpec struct {
 	Config string `json:"config"`
+}
+
+// NetworkAttachmentDefinitionStatus contains information for Status
+type NetworkAttachmentDefinitionStatus struct {
+	// ReconcilerState fields
+	ReconcilerState `json:",inline"`
+}
+
+// ReconcilerState permits to know if NetworkAttachmentDefinition was reconciled
+type ReconcilerState struct {
+	// State is the current state of the reconciliation. The state is updated
+	// during the process. See: State's type.
+	State StateType `json:"state"`
+
+	// Observation provides relative information related to the signature and
+	// state, example if an error happened.
+	Observation string `json:"observation"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
This PR adds Status field to `NetworkAttachmentDefinition`. 
The `Status` field contains `ReconcilerState` which can be used by `NetworkAttachmentDefinition` controller implementation to provide current `State` of the object and `Observation` related to the state.