### PR TITLE
Add omitempty tag for NetworkSelectionElement.CNIArgs

### DIFF
--- a/pkg/apis/k8s.cni.cncf.io/v1/types.go
+++ b/pkg/apis/k8s.cni.cncf.io/v1/types.go
@@ -156,7 +156,7 @@ type NetworkSelectionElement struct {
 	// the network
 	BandwidthRequest *BandwidthEntry `json:"bandwidth,omitempty"`
 	// CNIArgs contains additional CNI arguments for the network interface
-	CNIArgs *map[string]interface{} `json:"cni-args"`
+	CNIArgs *map[string]interface{} `json:"cni-args,omitempty"`
 	// GatewayRequest contains default route IP address for the pod
 	GatewayRequest []net.IP `json:"default-route,omitempty"`
 }


### PR DESCRIPTION
CNIArgs field is optional and we'd better to ommit it from the encoding if it has an empty value.