### PR TITLE
Removes requirement for version field for IPs [for release-v1.1 branch]

### DIFF
--- a/pkg/utils/net-attach-def.go
+++ b/pkg/utils/net-attach-def.go
@@ -142,13 +142,7 @@ func CreateNetworkStatus(r cnitypes.Result, networkName string, defaultNetwork b
 	}
 
 	for _, ipconfig := range result.IPs {
-		if ipconfig.Version == "4" && ipconfig.Address.IP.To4() != nil {
-			netStatus.IPs = append(netStatus.IPs, ipconfig.Address.IP.String())
-		}
-
-		if ipconfig.Version == "6" && ipconfig.Address.IP.To16() != nil {
-			netStatus.IPs = append(netStatus.IPs, ipconfig.Address.IP.String())
-		}
+		netStatus.IPs = append(netStatus.IPs, ipconfig.Address.IP.String())
 	}
 
 	v1dns := convertDNS(result.DNS)


### PR DESCRIPTION
This allows CNI version >= 1.0.0 formatted IP address sections to process into network-status annotations properly.