### PR TITLE
Update DeviceInfo spec to 1.1.0

### DIFF
--- a/pkg/apis/k8s.cni.cncf.io/v1/types.go
+++ b/pkg/apis/k8s.cni.cncf.io/v1/types.go
@@ -43,7 +43,7 @@ const (
 	DeviceInfoTypeVHostUser = "vhost-user"
 	DeviceInfoTypeMemif     = "memif"
 	DeviceInfoTypeVDPA      = "vdpa"
-	DeviceInfoVersion       = "1.0.0"
+	DeviceInfoVersion       = "1.1.0"
 )
 
 // DeviceInfo contains the information of the device associated
@@ -58,18 +58,20 @@ type DeviceInfo struct {
 }
 
 type PciDevice struct {
-	PciAddress   string `json:"pci-address,omitempty"`
-	Vhostnet     string `json:"vhost-net,omitempty"`
-	RdmaDevice   string `json:"rdma-device,omitempty"`
-	PfPciAddress string `json:"pf-pci-address,omitempty"`
+	PciAddress        string `json:"pci-address,omitempty"`
+	Vhostnet          string `json:"vhost-net,omitempty"`
+	RdmaDevice        string `json:"rdma-device,omitempty"`
+	PfPciAddress      string `json:"pf-pci-address,omitempty"`
+	RepresentorDevice string `json:"representor-device,omitempty"`
 }
 
 type VdpaDevice struct {
-	ParentDevice string `json:"parent-device,omitempty"`
-	Driver       string `json:"driver,omitempty"`
-	Path         string `json:"path,omitempty"`
-	PciAddress   string `json:"pci-address,omitempty"`
-	PfPciAddress string `json:"pf-pci-address,omitempty"`
+	ParentDevice      string `json:"parent-device,omitempty"`
+	Driver            string `json:"driver,omitempty"`
+	Path              string `json:"path,omitempty"`
+	PciAddress        string `json:"pci-address,omitempty"`
+	PfPciAddress      string `json:"pf-pci-address,omitempty"`
+	RepresentorDevice string `json:"representor-device,omitempty"`
 }
 
 const (

--- a/pkg/utils/net-attach-def_test.go
+++ b/pkg/utils/net-attach-def_test.go
@@ -145,10 +145,11 @@ var _ = Describe("Netwok Attachment Definition manipulations", func() {
 			BeforeEach(func() {
 				deviceInfo = &v1.DeviceInfo{
 					Type:    "pci",
-					Version: "v1.0.0",
+					Version: "v1.1.0",
 					Pci: &v1.PciDevice{
-						PciAddress:   "0000:01:02.2",
-						PfPciAddress: "0000:01:02.0",
+						PciAddress:        "0000:01:02.2",
+						PfPciAddress:      "0000:01:02.0",
+						RepresentorDevice: "eth3",
 					},
 				}
 				var err error
@@ -158,9 +159,10 @@ var _ = Describe("Netwok Attachment Definition manipulations", func() {
 
 			It("create network status from cni result", func() {
 				Expect(networkStatus.DeviceInfo.Type).To(Equal("pci"))
-				Expect(networkStatus.DeviceInfo.Version).To(Equal("v1.0.0"))
+				Expect(networkStatus.DeviceInfo.Version).To(Equal("v1.1.0"))
 				Expect(networkStatus.DeviceInfo.Pci.PciAddress).To(Equal("0000:01:02.2"))
 				Expect(networkStatus.DeviceInfo.Pci.PfPciAddress).To(Equal("0000:01:02.0"))
+				Expect(networkStatus.DeviceInfo.Pci.RepresentorDevice).To(Equal("eth3"))
 			})
 		})
 


### PR DESCRIPTION
Add "representor-device" field to support DeviceInfo format 1.1.0.

PR in DeviceInfoSpec repo https://github.com/k8snetworkplumbingwg/device-info-spec/pull/3
