### PR TITLE
Update types to support DeviceInfo spec to 1.1.0

### DIFF
--- a/pkg/apis/k8s.cni.cncf.io/v1/types.go
+++ b/pkg/apis/k8s.cni.cncf.io/v1/types.go
@@ -43,7 +43,7 @@ const (
 	DeviceInfoTypeVHostUser = "vhost-user"
 	DeviceInfoTypeMemif     = "memif"
 	DeviceInfoTypeVDPA      = "vdpa"
-	DeviceInfoVersion       = "1.0.0"
+	DeviceInfoVersion       = "1.1.0"
 )
 
 // DeviceInfo contains the information of the device associated
@@ -58,18 +58,20 @@ type DeviceInfo struct {
 }
 
 type PciDevice struct {
-	PciAddress   string `json:"pci-address,omitempty"`
-	Vhostnet     string `json:"vhost-net,omitempty"`
-	RdmaDevice   string `json:"rdma-device,omitempty"`
-	PfPciAddress string `json:"pf-pci-address,omitempty"`
+	PciAddress        string `json:"pci-address,omitempty"`
+	Vhostnet          string `json:"vhost-net,omitempty"`
+	RdmaDevice        string `json:"rdma-device,omitempty"`
+	PfPciAddress      string `json:"pf-pci-address,omitempty"`
+	RepresentorDevice string `json:"representor-device,omitempty"`
 }
 
 type VdpaDevice struct {
-	ParentDevice string `json:"parent-device,omitempty"`
-	Driver       string `json:"driver,omitempty"`
-	Path         string `json:"path,omitempty"`
-	PciAddress   string `json:"pci-address,omitempty"`
-	PfPciAddress string `json:"pf-pci-address,omitempty"`
+	ParentDevice      string `json:"parent-device,omitempty"`
+	Driver            string `json:"driver,omitempty"`
+	Path              string `json:"path,omitempty"`
+	PciAddress        string `json:"pci-address,omitempty"`
+	PfPciAddress      string `json:"pf-pci-address,omitempty"`
+	RepresentorDevice string `json:"representor-device,omitempty"`
 }
 
 const (

--- a/pkg/utils/net-attach-def_test.go
+++ b/pkg/utils/net-attach-def_test.go
@@ -129,10 +129,11 @@ var _ = Describe("Netwok Attachment Definition manipulations", func() {
 		}
 		devInfo := v1.DeviceInfo{
 			Type:    "pci",
-			Version: "v1.0.0",
+			Version: "v1.1.0",
 			Pci: &v1.PciDevice{
-				PciAddress:   "0000:01:02.2",
-				PfPciAddress: "0000:01:02.0",
+				PciAddress:        "0000:01:02.2",
+				PfPciAddress:      "0000:01:02.0",
+				RepresentorDevice: "eth3",
 			},
 		}
 		status, err := CreateNetworkStatus(cniResult, "test-net-attach-def", false, &devInfo)
@@ -142,9 +143,10 @@ var _ = Describe("Netwok Attachment Definition manipulations", func() {
 		Expect(status.Mac).To(Equal("92:79:27:01:7c:cf"))
 		Expect(status.IPs).To(Equal([]string{"1.1.1.3", "2001::1"}))
 		Expect(status.DeviceInfo.Type).To(Equal("pci"))
-		Expect(status.DeviceInfo.Version).To(Equal("v1.0.0"))
+		Expect(status.DeviceInfo.Version).To(Equal("v1.1.0"))
 		Expect(status.DeviceInfo.Pci.PciAddress).To(Equal("0000:01:02.2"))
 		Expect(status.DeviceInfo.Pci.PfPciAddress).To(Equal("0000:01:02.0"))
+		Expect(status.DeviceInfo.Pci.RepresentorDevice).To(Equal("eth3"))
 	})
 
 	It("parse network selection element in pod", func() {


### PR DESCRIPTION
Update DeviceInfo spec in v1.1 branch.
This required to be able to use updated DeviceInfo spec in multus v3.

@maiqueb @adrianchiris 