### PR TITLE
Add NOTICE file for Apache license 2.0

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,1 @@
+Copyright 2018 Kubernetes Network Plumbing Working Group


### PR DESCRIPTION
This change adds NOTICE file in repository as https://infra.apache.org/apply-license.html#new