### PR TITLE
Support for HostIFName in DeviceInfo and vfid in PciDevice

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/network-attachment-definition-client.iml" filepath="$PROJECT_DIR$/.idea/network-attachment-definition-client.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/network-attachment-definition-client.iml
+++ b/.idea/network-attachment-definition-client.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/pkg/apis/k8s.cni.cncf.io/v1/types.go
+++ b/pkg/apis/k8s.cni.cncf.io/v1/types.go
@@ -51,12 +51,13 @@ const (
 // DeviceInfo contains the information of the device associated
 // with this network (if any)
 type DeviceInfo struct {
-	Type      string       `json:"type,omitempty"`
-	Version   string       `json:"version,omitempty"`
-	Pci       *PciDevice   `json:"pci,omitempty"`
-	Vdpa      *VdpaDevice  `json:"vdpa,omitempty"`
-	VhostUser *VhostDevice `json:"vhost-user,omitempty"`
-	Memif     *MemifDevice `json:"memif,omitempty"`
+	Type       string       `json:"type,omitempty"`
+	Version    string       `json:"version,omitempty"`
+	HostIFName string       `json:"hostifname,omitempty"`
+	Pci        *PciDevice   `json:"pci,omitempty"`
+	Vdpa       *VdpaDevice  `json:"vdpa,omitempty"`
+	VhostUser  *VhostDevice `json:"vhost-user,omitempty"`
+	Memif      *MemifDevice `json:"memif,omitempty"`
 }
 
 type PciDevice struct {
@@ -65,6 +66,7 @@ type PciDevice struct {
 	RdmaDevice        string `json:"rdma-device,omitempty"`
 	PfPciAddress      string `json:"pf-pci-address,omitempty"`
 	RepresentorDevice string `json:"representor-device,omitempty"`
+	VfId              string `json:"vf-id,omitempty"`
 }
 
 type VdpaDevice struct {

--- a/pkg/utils/net-attach-def_test.go
+++ b/pkg/utils/net-attach-def_test.go
@@ -147,12 +147,14 @@ var _ = Describe("Netwok Attachment Definition manipulations", func() {
 
 			BeforeEach(func() {
 				deviceInfo = &v1.DeviceInfo{
-					Type:    "pci",
-					Version: "v1.1.0",
+					Type:       "pci",
+					Version:    "v1.1.0",
+					HostIFName: "enp0s10v5",
 					Pci: &v1.PciDevice{
 						PciAddress:        "0000:01:02.2",
 						PfPciAddress:      "0000:01:02.0",
 						RepresentorDevice: "eth3",
+						VfId:              "1",
 					},
 				}
 				var err error
@@ -163,9 +165,30 @@ var _ = Describe("Netwok Attachment Definition manipulations", func() {
 			It("create network status from cni result", func() {
 				Expect(networkStatus.DeviceInfo.Type).To(Equal("pci"))
 				Expect(networkStatus.DeviceInfo.Version).To(Equal("v1.1.0"))
+				Expect(networkStatus.DeviceInfo.HostIFName).To(Equal("enp0s10v5"))
 				Expect(networkStatus.DeviceInfo.Pci.PciAddress).To(Equal("0000:01:02.2"))
 				Expect(networkStatus.DeviceInfo.Pci.PfPciAddress).To(Equal("0000:01:02.0"))
 				Expect(networkStatus.DeviceInfo.Pci.RepresentorDevice).To(Equal("eth3"))
+				Expect(networkStatus.DeviceInfo.Pci.VfId).To(Equal("1"))
+			})
+		})
+
+		When("DeviceInfo Used as an attribute, but does not need to have a deviceid", func() {
+			var deviceInfo *v1.DeviceInfo
+
+			BeforeEach(func() {
+				deviceInfo = &v1.DeviceInfo{
+					Type:       "veth",
+					HostIFName: "veth61efac1c",
+				}
+				var err error
+				networkStatus, err = CreateNetworkStatus(cniResult, "test-net-attach-def", false, deviceInfo)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("create network status from cni result", func() {
+				Expect(networkStatus.DeviceInfo.Type).To(Equal("veth"))
+				Expect(networkStatus.DeviceInfo.HostIFName).To(Equal("veth61efac1c"))
 			})
 		})
 


### PR DESCRIPTION
1.The addition of these two fields is mainly to adapt to the deviceinfo of more types of network cards, such as veth in Calico and ovs-cni. Among them, ovs-cni has a greater need for this field. It relies on delivering flow tables under the vethName on the host to divert traffic. Adding this field can bind the vethName on the host with the corresponding Pod, eliminating the need to store the mapping between ovs and Pod in a separate database. I will adapt this content in a subsequent ovs-cni PR.

2.In metric monitoring, more information about the VF network card is needed, such as vfid and OrigVfName. I will later add OrigVfName to HostIFName and vfid to vfid in sriov-cni to facilitate reading the Pod's VfName and vfid.