### PR TITLE
Accont for non-sandbox interfaces when specifying the default network

### DIFF
--- a/pkg/utils/net-attach-def.go
+++ b/pkg/utils/net-attach-def.go
@@ -149,11 +149,12 @@ func CreateNetworkStatuses(r cnitypes.Result, networkName string, defaultNetwork
 
 	// Initialize NetworkStatus for each container interface (e.g. with sandbox present)
 	indexOfFoundPodInterface := 0
+	foundFirstSandboxIface := false
 	for i, iface := range result.Interfaces {
 		if iface.Sandbox != "" {
 			ns := &v1.NetworkStatus{
 				Name:       networkName,
-				Default:    defaultNetwork && i == 0,
+				Default:    defaultNetwork && !foundFirstSandboxIface,
 				Interface:  iface.Name,
 				Mac:        iface.Mac,
 				Mtu:        iface.Mtu,
@@ -166,6 +167,7 @@ func CreateNetworkStatuses(r cnitypes.Result, networkName string, defaultNetwork
 			// Map original index to the new slice index
 			indexMap[i] = indexOfFoundPodInterface
 			indexOfFoundPodInterface++
+			foundFirstSandboxIface = true
 		}
 	}
 

--- a/pkg/utils/net-attach-def_test.go
+++ b/pkg/utils/net-attach-def_test.go
@@ -233,14 +233,14 @@ var _ = Describe("Netwok Attachment Definition manipulations", func() {
 				CNIVersion: "1.1.0",
 				Interfaces: []*cni100.Interface{
 					{
+						Name: "foo",
+						Mac:  "00:AA:BB:CC:DD:33",
+					},
+					{
 						Name:    "example0",
 						Mac:     "00:AA:BB:CC:DD:01",
 						Sandbox: "/path/to/network/namespace",
 						Mtu:     1500,
-					},
-					{
-						Name: "foo",
-						Mac:  "00:AA:BB:CC:DD:33",
 					},
 					{
 						Name:    "example1",
@@ -252,11 +252,11 @@ var _ = Describe("Netwok Attachment Definition manipulations", func() {
 				IPs: []*cni100.IPConfig{
 					{
 						Address:   *EnsureCIDR("192.0.2.1/24"),
-						Interface: &[]int{0}[0],
+						Interface: &[]int{1}[0],
 					},
 					{
 						Address:   *EnsureCIDR("192.0.2.2/24"),
-						Interface: &[]int{0}[0],
+						Interface: &[]int{1}[0],
 					},
 					{
 						Address:   *EnsureCIDR("192.0.2.3/24"),


### PR DESCRIPTION
We only account for the sandox interfaces when reporting the interfaces in the network-status annotation; in case the `CreateNetworkStatuses` clients invoke it with a CNI result featuring non-sandbox interfaces as the first item in the list, the existing criteria would not work, and we would fail to report **any** interface as the default.