### PR TITLE
Preserve backwards compatibility of CreateNetworkStatus

### DIFF
--- a/pkg/utils/net-attach-def.go
+++ b/pkg/utils/net-attach-def.go
@@ -136,6 +136,11 @@ func CreateNetworkStatuses(r cnitypes.Result, networkName string, defaultNetwork
 		return nil, fmt.Errorf("error converting the type.Result to cni100.Result: %v", err)
 	}
 
+	if len(result.Interfaces) == 1 {
+		networkStatus, err := CreateNetworkStatus(r, networkName, defaultNetwork, dev)
+		return []*v1.NetworkStatus{networkStatus}, err
+	}
+
 	// Discover default routes upfront and reuse them if necessary.
 	var useDefaultRoute []string
 	for _, route := range result.Routes {


### PR DESCRIPTION
The [CNI spec](https://github.com/containernetworking/cni/blob/main/SPEC.md#add-success) states that the `sandbox` attribute in the CNI result should be used to represent:

> The isolation domain reference (e.g. path to network namespace) for the
interface, or empty if on the host. For interfaces created inside the container,
this should be the value passed via CNI_NETNS

Some CNIs (like calico) do **not** set the sandbox for their interfaces (below you'll find an example of a cached CNI result created by calico CNI):
```json
{
  "result": {
    "cniVersion": "0.3.1",
    "dns": {},
    "interfaces": [
      {
        "name": "cali05f4a1849c5"
      }
    ],
    "ips": [
      {
        "address": "10.244.196.152/32",
        "version": "4"
      },
      {
        "address": "fd10:244::c497/128",
        "version": "6"
      }
    ]
  }
}
```

Thus, when multus started to use `CreateNetworkStatuses` (plural) we broke calico users relying on the network-status annotations (since that function relies on the sandbox attribute being defined to identify container interfaces).

This commit changes the code to use the original status creation whenever `CreateNetworkStatuses` is created with a single interface, thus ensuring the original behavior will be provided to user. Unit tests are also added.
