### PR TITLE
Assign IPs that don't have an interface index to the last network status

### DIFF
--- a/pkg/utils/net-attach-def.go
+++ b/pkg/utils/net-attach-def.go
@@ -207,6 +207,12 @@ func CreateNetworkStatuses(r cnitypes.Result, networkName string, defaultNetwork
 		}
 	}
 
+	var defaultNetworkStatus *v1.NetworkStatus
+	if len(networkStatuses) > 0 {
+		// Set the default network status to the last network status.
+		defaultNetworkStatus = networkStatuses[len(networkStatuses)-1]
+	}
+
 	// Map IPs to network interface based on index
 	for _, ipConfig := range result.IPs {
 		if ipConfig.Interface != nil {
@@ -214,6 +220,12 @@ func CreateNetworkStatuses(r cnitypes.Result, networkName string, defaultNetwork
 			if newIndex, ok := indexMap[originalIndex]; ok {
 				ns := networkStatuses[newIndex]
 				ns.IPs = append(ns.IPs, ipConfig.Address.IP.String())
+			}
+		} else {
+			// If the IPs don't specify the interface assign the IP to the default network status. This keeps the behaviour
+			// consistent with previous multus versions.
+			if defaultNetworkStatus != nil {
+				defaultNetworkStatus.IPs = append(defaultNetworkStatus.IPs, ipConfig.Address.IP.String())
 			}
 		}
 	}

--- a/pkg/utils/net-attach-def_test.go
+++ b/pkg/utils/net-attach-def_test.go
@@ -280,6 +280,70 @@ var _ = Describe("Netwok Attachment Definition manipulations", func() {
 		})
 	})
 
+	Context("create network statuses from CNI result with multiple interfaces when the IP Interface index isn't set", func() {
+		When("one sandbox interface is specified", func() {
+			It("assigns the IPs to the last sandbox interface specified", func() {
+				cniResult := &cni100.Result{
+					CNIVersion: "1.0.0",
+					Interfaces: []*cni100.Interface{
+						{
+							Name: "foo",
+						},
+						{
+							Name:    "eth0",
+							Mac:     "00:AA:BB:CC:DD:01",
+							Sandbox: "/path/to/network/namespace",
+						},
+					},
+					IPs: []*cni100.IPConfig{
+						{
+							Address: *EnsureCIDR("192.0.2.1/24"),
+						},
+					},
+				}
+				networkStatuses, err := CreateNetworkStatuses(cniResult, "test-multi-net-attach-def", false, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(networkStatuses).To(HaveLen(1))
+				Expect(networkStatuses[0].Interface).To(Equal("eth0"))
+				Expect(networkStatuses[0].IPs).To(ConsistOf("192.0.2.1"))
+			})
+		})
+		When("two sandbox interfaces are specified", func() {
+			It("assigns the IPs to the last sandbox interface specified", func() {
+				cniResult := &cni100.Result{
+					CNIVersion: "1.0.0",
+					Interfaces: []*cni100.Interface{
+						{
+							Name: "foo",
+						},
+						{
+							Name:    "eth0",
+							Mac:     "00:AA:BB:CC:DD:01",
+							Sandbox: "/path/to/network/namespace",
+						},
+						{
+							Name:    "eth1",
+							Mac:     "00:ZZ:BB:CC:DD:01",
+							Sandbox: "/path/to/other/network/namespace",
+						},
+					},
+					IPs: []*cni100.IPConfig{
+						{
+							Address: *EnsureCIDR("192.0.2.1/24"),
+						},
+					},
+				}
+				networkStatuses, err := CreateNetworkStatuses(cniResult, "test-multi-net-attach-def", false, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(networkStatuses).To(HaveLen(2))
+				Expect(networkStatuses[0].Interface).To(Equal("eth0"))
+				Expect(networkStatuses[0].IPs).To(BeEmpty())
+				Expect(networkStatuses[1].Interface).To(Equal("eth1"))
+				Expect(networkStatuses[1].IPs).To(ConsistOf("192.0.2.1"))
+			})
+		})
+	})
+
 	Context("create network statuses from CNI result with multiple interfaces", func() {
 		var cniResult *cni100.Result
 		var networkStatuses []*v1.NetworkStatus

--- a/pkg/utils/net-attach-def_test.go
+++ b/pkg/utils/net-attach-def_test.go
@@ -287,12 +287,12 @@ var _ = Describe("Netwok Attachment Definition manipulations", func() {
 					CNIVersion: "1.0.0",
 					Interfaces: []*cni100.Interface{
 						{
-							Name: "foo",
-						},
-						{
 							Name:    "eth0",
 							Mac:     "00:AA:BB:CC:DD:01",
 							Sandbox: "/path/to/network/namespace",
+						},
+						{
+							Name: "foo",
 						},
 					},
 					IPs: []*cni100.IPConfig{


### PR DESCRIPTION
This fixes a regression where CNI plugins that don't specify interfaces aren't assigned to any network status. Previously they were assigned to the last network status.